### PR TITLE
fixing IPv6 issue for resolving IPv6's behind domain in auto cdn

### DIFF
--- a/hiddifypanel/panel/hiddify.py
+++ b/hiddifypanel/panel/hiddify.py
@@ -254,7 +254,7 @@ def get_domain_ip(dom, retry=3):
 
     if not res:
         try:
-            res = socket.getaddrinfo(dom, None, socket.AF_INET6)[0][4][0]
+            res = f"[{socket.getaddrinfo(dom, None, socket.AF_INET6)[0][4][0]}]" 
         except:
             pass
 


### PR DESCRIPTION
adding brackets to avoid errors when converting domains to ipv6.

aaaa:bbbb:cccc:dddd -> [aaaa:bbbb:cccc:dddd]