### PR TITLE
enhancements for xray, sing-box, clash configs

### DIFF
--- a/hiddifypanel/panel/user/templates/base_singbox_config.json.j2
+++ b/hiddifypanel/panel/user/templates/base_singbox_config.json.j2
@@ -1,5 +1,6 @@
 {% set V1_7= g.user_agent['is_singbox'] and g.user_agent['singbox_version'][0]==1 and g.user_agent['singbox_version'][1]<8 %}
 {% set V1_9= g.user_agent['is_singbox'] and g.user_agent['singbox_version'][0]==1 and g.user_agent['singbox_version'][1]<10 %}
+
 {
     "outbounds": [
         {
@@ -26,46 +27,30 @@
         {% if V1_7 %}
         "geoip": {
                "download_url": "https://github.com/SagerNet/sing-geoip/releases/latest/download/geoip.db",
-               "download_detour": {% if hconfig(ConfigEnum.country)=='cn' %}"Select" {%else%}"bypass"{%endif%} 
+               "download_detour": {% if hconfig(ConfigEnum.country)=='zh' %}"Select" {%else%}"bypass"{%endif%} 
             },
         "geosite": {
             "download_url": "https://github.com/SagerNet/sing-geosite/releases/latest/download/geosite.db",
-            "download_detour": {% if hconfig(ConfigEnum.country)=='cn' %}"Select" {%else%}"bypass"{%endif%} 
+            "download_detour": {% if hconfig(ConfigEnum.country)=='zh' %}"Select" {%else%}"bypass"{%endif%} 
         }, 
         {%else%}
         "rule_set": [
-            {%if hconfig(ConfigEnum.country)=="ir"%}
+            {%if hconfig(ConfigEnum.country) in ["ir","zh","ru"]%}
             {
-                "tag": "geosite-ir",
+                "tag": "geosite-{{hconfig(ConfigEnum.country)|replace('zh', 'cn')}}",
                 "type": "remote",
                 "format": "binary",
-                "url": "https:\/\/raw.githubusercontent.com\/Chocolate4U\/Iran-sing-box-rules\/rule-set\/geosite-ir.srs",
-                "download_detour": "bypass" 
+                "url": "https:\/\/github.com\/hiddify\/hiddify-geo\/raw\/rule-set\/country\/geosite-{{hconfig(ConfigEnum.country)|replace('zh', 'cn')}}.srs",
+                "download_detour": {% if hconfig(ConfigEnum.country)=='zh' %}"Select" {%else%}"bypass"{%endif%}
             },
             {
-            "tag": "geoip-ir",
+            "tag": "geoip-{{hconfig(ConfigEnum.country)|replace('zh', 'cn')}}",
             "type": "remote",
             "format": "binary",
-            "url": "https:\/\/raw.githubusercontent.com\/Chocolate4U\/Iran-sing-box-rules\/rule-set\/geoip-ir.srs",
-            "download_detour": "bypass"
+            "url": "https:\/\/github.com\/hiddify\/hiddify-geo\/raw\/rule-set\/country\/geoip-{{hconfig(ConfigEnum.country)|replace('zh', 'cn')}}.srs",
+            "download_detour": {% if hconfig(ConfigEnum.country)=='zh' %}"Select" {%else%}"bypass"{%endif%} 
             }
-            {%endif%}
-            {%if hconfig(ConfigEnum.country)=="ru"%}
-            {
-                "tag": "geosite-ru",
-                "type": "remote",
-                "format": "binary",
-                "url": "https:\/\/github.com\/SagerNet\/sing-geosite\/raw\/rule-set\/geosite-category-ru.srs",
-                "download_detour": "bypass" 
-            },
-            {
-            "tag": "geoip-ru",
-            "type": "remote",
-            "format": "binary",
-            "url": "https:\/\/github.com\/SagerNet\/sing-geoip\/raw\/rule-set\/geoip-ru.srs",
-            "download_detour": "bypass"
-            }
-            {%endif%}
+            {%endif%}               
             {# {
                 "tag": "geosite-category-ads-all",
                 "type": "remote",
@@ -88,10 +73,10 @@
                 ],
                 "outbound": "dns-out"
             },
-            {%if hconfig(ConfigEnum.country) in ["ir","cn","ru"]%}
+            {%if hconfig(ConfigEnum.country)in ["ir","zh","ru"]%}
             {
                 "domain_suffix": [
-                    "{{hconfig(ConfigEnum.country)}}"
+                    "{{hconfig(ConfigEnum.country)|replace('zh', 'cn')}}"
                 ],
                 "outbound": "bypass"
             },
@@ -105,19 +90,19 @@
                 {%endif%}
                 "outbound": "block"
             }, #}
-            {%if hconfig(ConfigEnum.country) in ["ir","cn","ru"]%}
+            {%if hconfig(ConfigEnum.country) in ["ir","zh","ru"]%}
             {% if V1_7 %}
             {
-                "geoip": ["{{hconfig(ConfigEnum.country)}}"],
+                "geoip": ["{{hconfig(ConfigEnum.country)|replace('zh', 'cn')}}"],
                 "outbound": "bypass"
             },
             {%else%}
             {
-                "rule_set": "geoip-{{hconfig(ConfigEnum.country)}}",
+                "rule_set": "geoip-{{hconfig(ConfigEnum.country)|replace('zh', 'cn')}}",
                 "outbound": "bypass"
             },
             {
-                "rule_set": "geosite-{{hconfig(ConfigEnum.country)}}",
+                "rule_set": "geosite-{{hconfig(ConfigEnum.country)|replace('zh', 'cn')}}",
                 "outbound": "bypass"
             },
             {%endif%}
@@ -192,10 +177,10 @@
                 ],
                 "server": "dns-local"
             },
-            {%if hconfig(ConfigEnum.country)in ["ir","cn","ru"]%}
+            {%if hconfig(ConfigEnum.country)in ["ir","zh","ru"]%}
             {
                 "domain_suffix": [
-                    "{{hconfig(ConfigEnum.country)}}"
+                    "{{hconfig(ConfigEnum.country)|replace('zh', 'cn')}}"
                 ],
                 "server": "dns-local"
             },

--- a/hiddifypanel/panel/user/templates/base_xray_config.json.j2
+++ b/hiddifypanel/panel/user/templates/base_xray_config.json.j2
@@ -98,7 +98,8 @@
         "outboundTag": "direct",
         "domain": [
           "domain:ir",
-          "geosite:cn"
+          "geosite:cn",
+          "geosite:category-ru"
         ],
         "enabled": true
       },
@@ -109,7 +110,8 @@
         "ip": [
           "geoip:private",
           "geoip:cn",
-          "geoip:ir"
+          "geoip:ir",
+          "geoip:ru"
         ],
         "enabled": true
       },

--- a/hiddifypanel/panel/user/templates/clash_config.yml
+++ b/hiddifypanel/panel/user/templates/clash_config.yml
@@ -135,7 +135,33 @@ proxy-groups:
 #   %endfor
 #   %endfor
 rule-providers:
-
+{% if hconfig(ConfigEnum.country) in ["ir","zh","ru"] %}
+  geoip_{{hconfig(ConfigEnum.country)}}:
+    type: http
+    behavior: classical
+    url: "https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geoip/classical/{{hconfig(ConfigEnum.country)|replace('zh', 'cn')}}.yaml"
+    path: ./geoip/{{hconfig(ConfigEnum.country)}}.yaml
+    interval: 432000
+    
+{% endif %}
+{% if hconfig(ConfigEnum.country)=="zh" %}
+  geosite_cn:
+    type: http
+    behavior: classical
+    url: "https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo-lite/geosite/classical/cn.yaml"
+    path: ./geosite/zh.yaml
+    interval: 86400
+    
+{% endif %}
+{% if hconfig(ConfigEnum.country) in ["ir","ru"] %}
+  geosite_{{hconfig(ConfigEnum.country)}}:
+    type: http
+    behavior: classical
+    url: "https://github.com/MetaCubeX/meta-rules-dat/raw/meta/geo/geosite/classical/category-{{hconfig(ConfigEnum.country)}}.yaml"
+    path: ./geosite/{{hconfig(ConfigEnum.country)}}.yaml
+    interval: 86400
+    
+{% endif %}
   blocked:
     type: http
     behavior: classical
@@ -175,9 +201,13 @@ rules:
   # - IP-CIDR,10.10.34.0/24,{{OnProxyIssue}}
   # - RULE-SET,tmpblocked,{{OnProxyIssue}}
   # - RULE-SET,blocked,{{OnProxyIssue}}
-  - GEOIP,IR,{{OnIranSites}}
-  - DOMAIN-SUFFIX,.ir,{{OnIranSites}}
+{% if hconfig(ConfigEnum.country) in ["ir","zh","ru"] %}
+  - RULE-SET,geoip_{{hconfig(ConfigEnum.country)|replace('zh', 'cn')}},DIRECT
+  - RULE-SET,geosite_{{hconfig(ConfigEnum.country)|replace('zh', 'cn')}},DIRECT
+{% endif %}
+{% if hconfig(ConfigEnum.country)=="ir" %}
   - RULE-SET,open,{{OnIranSites}}
+{% endif %}
   # - RULE-SET,ads,REJECT
   - MATCH,{{OnNotFilteredSites}}
 


### PR DESCRIPTION
clash config:
replace zh to cn for correct create config
add geoip&geosite rule-sets for ir,cn,ru with DIRECT route GEOIP,IR & DOMAIN-SUFFIX,.ir replace to rule-sets

sing-box:
replace zh to cn for correct create config
replace .srs links to .srs from hiddify-geo
fix rule-set sing-box 1.8+ for .cn

xray config:
add geoip:ru & geosite:category-ru for DIRECT