### PR TITLE
Fix: Bypass authentication for Telegram webhook to enable bot functionality

### DIFF
--- a/hiddifypanel/panel/common.py
+++ b/hiddifypanel/panel/common.py
@@ -158,6 +158,10 @@ def init_app(app: APIFlask):
 
         if g.user_agent['is_bot']:
             abort(400, "invalid")
+            
+        # Ignore authentication for Telegram webhook
+        if 'api/v1/tgbot' in request.path and request.method == 'POST':
+            return None
 
         g.proxy_path = hutils.flask.get_proxy_path_from_url(request.url)
         hutils.flask.proxy_path_validator(g.proxy_path)


### PR DESCRIPTION
Currently, the Telegram bot functionality is broken due to authentication requirements on the webhook endpoint. This PR fixes the issue by bypassing authentication specifically for Telegram webhook requests.

**Problem:**
The Telegram bot's webhook requests are being blocked by the panel's authentication middleware, resulting in HTTP 500 errors. This happens because Telegram's servers cannot provide the authentication credentials required by our middleware.

**Technical Details:**

- Telegram sends webhook requests as unauthenticated POST requests to our endpoint
- Telegram does not support sending custom authentication headers with webhook requests
- The current middleware forces authentication for all routes, causing webhook requests to fail
- This results in the bot being unable to receive and process messages from users

**Solution:**
Added a specific exception in the base_middleware to bypass authentication for Telegram webhook requests. This is a secure approach because:
1. It only affects POST requests to the specific bot endpoint
2. Telegram provides its own verification through the bot token
3. The webhook URL contains a UUID which acts as an additional security measure

**Alternative approaches considered:**
- Adding authentication to webhook requests: Not possible as Telegram doesn't support custom headers in webhooks
- Using a separate endpoint: Would require significant architectural changes

**Testing:**
- Webhook now receives requests successfully
- Bot responds to commands as expected
- Other authenticated routes remain secure