### PR TITLE
Fix: Don't return ASN

### DIFF
--- a/hiddifypanel/hutils/network/auto_ip_selector.py
+++ b/hiddifypanel/hutils/network/auto_ip_selector.py
@@ -192,4 +192,4 @@ def get_clean_ip_user(user_ip, ipliststr: str, default_asn: str = '') -> tuple[s
     else:
         selected_server = random.sample(ips, 1)[0]
     # print("selected_server",selected_server)
-    return str(selected_server), asn_short
+    return str(selected_server)


### PR DESCRIPTION
This fix removes problem of generating invalid config for at least sing-box.

When setting up domain, we can fill field "Force Config to Use Following IPs" to make clients connect to specific ips or domains. If we don't use this field, we get our server ip in singbox config. But when we use this field, we expect to see one of ips/domains in singbox config. The problem is we get in "server" field of config value like "('1.2.3.4', 'unknown')" despite putting "1.2.3.4" in domain settings. This happens because function get_clean_ip_user now returns 2 values instead of one. Because of this, config builds from ip/domain and short asn, instead of just ip/domain. In my case, asn was "unknown", but the error will persist even with some valid asn.