### PR TITLE
fix(admin): correct max active users count in admin list

### DIFF
--- a/hiddifypanel/panel/admin/AdminstratorAdmin.py
+++ b/hiddifypanel/panel/admin/AdminstratorAdmin.py
@@ -143,8 +143,9 @@ class AdminstratorAdmin(AdminLTEModelView):
         """)
 
     def _max_active_users_formatter(view, context, model, name):
-        """Optimized user count formatter using database queries"""
-        active_count = model.recursive_users_query().filter(User.is_active == True).count()
+        # `User.is_active` is a python property, not a SQL column.
+        # So we must evaluate it on model instances instead of using query.filter.
+        active_count = sum(1 for user in model.recursive_users_query().all() if user.is_active)
         if model.mode == AdminMode.super_admin:
             return f"{active_count} / ∞"
         t = model.max_active_users


### PR DESCRIPTION
Summary:
- Fix Max Active Users always showing 0 in Admin list.
- Count active users in Python because User.is_active is not a SQL column.

Root cause:
- User.is_active is a computed property, so SQL filter(User.is_active == True) cannot work as intended.

Validation:
- Local py_compile passed for hiddifypanel/panel/admin/AdminstratorAdmin.py.