### PR TITLE
feat(tls-trick): make fragment packets configurable

### DIFF
--- a/hiddifypanel/hutils/proxy/shared.py
+++ b/hiddifypanel/hutils/proxy/shared.py
@@ -455,6 +455,7 @@ def make_proxy(hconfigs: dict, proxy: Proxy, domain_db: Domain, phttp=80, ptls=4
             base["tls_fragment_enable"] = True
             base["tls_fragment_size"] = hconfigs[ConfigEnum.tls_fragment_size]
             base["tls_fragment_sleep"] = hconfigs[ConfigEnum.tls_fragment_sleep]
+            base["tls_fragment_packets"] = hconfigs.get(ConfigEnum.tls_fragment_packets, "tlshello")
 
         if hconfigs[ConfigEnum.tls_mixed_case]:
             base["tls_mixed_case"] = hconfigs[ConfigEnum.tls_mixed_case]

--- a/hiddifypanel/hutils/proxy/singbox.py
+++ b/hiddifypanel/hutils/proxy/singbox.py
@@ -71,7 +71,7 @@ def to_singbox(proxy: dict) -> list[dict] | dict:
             base['xray_outbound_raw'] = xp
             if proxy.get('tls_fragment_enable'):
                 base['xray_fragment'] = {
-                    'packets': "tlshello",
+                    'packets': proxy.get("tls_fragment_packets", "tlshello"),
                     'length': proxy["tls_fragment_size"],
                     'interval': proxy["tls_fragment_sleep"]
                 }

--- a/hiddifypanel/hutils/proxy/xray.py
+++ b/hiddifypanel/hutils/proxy/xray.py
@@ -235,7 +235,7 @@ def add_tls_tricks_to_dict(d: dict, proxy: dict):
         #     d['fragment'] = f'1,{proxy["tls_fragment_size"]},{proxy["tls_fragment_sleep"]}'
         # else:
 
-        d['fragment'] = f'{proxy["tls_fragment_size"]},{proxy["tls_fragment_sleep"]},tlshello'
+        d['fragment'] = f'{proxy["tls_fragment_size"]},{proxy["tls_fragment_sleep"]},{proxy.get("tls_fragment_packets", "tlshello")}'
         # if g.user_agent.get('is_streisand'):
         # else:
         #     d['fragment'] = f'tlshello,{proxy["tls_fragment_size"]},{proxy["tls_fragment_sleep"]}'

--- a/hiddifypanel/models/config_enum.py
+++ b/hiddifypanel/models/config_enum.py
@@ -170,6 +170,7 @@ class ConfigEnum(metaclass=FastEnum):
     tls_fragment_enable = _BoolConfigDscr(ConfigCategory.tls_trick)
     tls_fragment_size = _StrConfigDscr(ConfigCategory.tls_trick)
     tls_fragment_sleep = _StrConfigDscr(ConfigCategory.tls_trick)
+    tls_fragment_packets = _StrConfigDscr(ConfigCategory.tls_trick)
     tls_mixed_case = _BoolConfigDscr(ConfigCategory.tls_trick)
     tls_padding_enable = _BoolConfigDscr(ConfigCategory.tls_trick, ApplyMode.apply_config)
     tls_padding_length = _StrConfigDscr(ConfigCategory.tls_trick, ApplyMode.apply_config)

--- a/hiddifypanel/panel/admin/SettingAdmin.py
+++ b/hiddifypanel/panel/admin/SettingAdmin.py
@@ -331,6 +331,8 @@ def get_config_form():
                 # tls tricks validations
                 if c.key in [ConfigEnum.tls_fragment_size, ConfigEnum.tls_fragment_sleep, ConfigEnum.tls_padding_length, ConfigEnum.wireguard_noise_trick]:
                     validators.append(wtf.validators.Regexp("^\\d+-\\d+$", re.IGNORECASE, _("config.Invalid_The_pattern_is_number-number") + f' {c.key}'))
+                if c.key == ConfigEnum.tls_fragment_packets:
+                    validators.append(wtf.validators.Regexp("^(tlshello|\\d+-\\d+)$", re.IGNORECASE, _("config.Invalid_The_pattern_is_number-number") + f' {c.key}'))
                 # mux and hysteria validations
                 if c.key in [ConfigEnum.hysteria_up_mbps, ConfigEnum.hysteria_down_mbps, ConfigEnum.mux_max_connections, ConfigEnum.mux_min_streams, ConfigEnum.mux_max_streams,
                              ConfigEnum.mux_brutal_down_mbps, ConfigEnum.mux_brutal_up_mbps]:
@@ -344,8 +346,13 @@ def get_config_form():
                 if c.key == ConfigEnum.reality_public_key and g.account.mode in [AdminMode.super_admin]:
                     extra_info = f" <a href='{hurl_for('admin.Actions:change_reality_keys')}'>{_('Change')}</a>"
 
-                field = wtf.StringField(_(f'config.{c.key}.label'), validators, default=c.value,
-                                        description=_(f'config.{c.key}.description') + extra_info, render_kw=render_kw)
+                label = _(f'config.{c.key}.label')
+                description = _(f'config.{c.key}.description') + extra_info
+                if c.key == ConfigEnum.tls_fragment_packets:
+                    label = "📦 TLS Fragment Packets"
+                    description = "Fragment packets mode (for example: tlshello or 1-3)"
+                field = wtf.StringField(label, validators, default=c.value,
+                                        description=description, render_kw=render_kw)
             setattr(CategoryForm, f'{c.key}', field)
 
         multifield = wtf.FormField(CategoryForm, Markup('<i class="fa-solid fa-plus"></i>&nbsp' + _(f'config.{cat}.label')))

--- a/hiddifypanel/panel/init_db.py
+++ b/hiddifypanel/panel/init_db.py
@@ -21,6 +21,10 @@ def _v108(child_id):
         "mode":"cdn",
         "resolve_ip":True
     })
+
+
+def _v109(child_id):
+    add_config_if_not_exist(ConfigEnum.tls_fragment_packets, "tlshello")
     
 def _v107(child_id):
     # set_hconfig(ConfigEnum.core_type,'xray') # disable singbox core temporary

--- a/hiddifypanel/panel/user/templates/base_xray_config.json.j2
+++ b/hiddifypanel/panel/user/templates/base_xray_config.json.j2
@@ -53,7 +53,7 @@
         "domainStrategy": "AsIs"
         {% if hconfig(ConfigEnum.tls_fragment_enable) %}
         ,"fragment": {
-          "packets": "tlshello",
+          "packets": "{{ hconfig(ConfigEnum.tls_fragment_packets) or 'tlshello' }}",
           "length": "{{ hconfig(ConfigEnum.tls_fragment_size) }}",
           "interval": "{{ hconfig(ConfigEnum.tls_fragment_sleep) }}"
         }


### PR DESCRIPTION
## Summary
- add `tls_fragment_packets` config under TLS Trick settings
- replace hardcoded `tlshello` with configurable value in xray links, xray json template, and singbox xray fragment
- keep backward compatibility with default fallback to `tlshello`
- add DB init migration for existing installs
- validate accepted values as `tlshello` or `number-number` (e.g. `1-3`)

## Why
Some clients/network conditions need different fragment packet modes; currently this is hardcoded.

## Notes
- minimal-touch implementation aligned with existing config flow
- no behavior change unless user sets the new option
