### PR TITLE
Fix missing WireGuard local interface address in sing-box subscription JSON for Hiddify clients.

### DIFF
--- a/hiddifypanel/hutils/proxy/singbox.py
+++ b/hiddifypanel/hutils/proxy/singbox.py
@@ -381,6 +381,7 @@ def add_wireguard(base: dict, proxy: dict):
         
         base["private_key"] = proxy["wg_pk"]
         base["mtu"] = 1380
+        base["address"] = [f'{proxy["wg_ipv4"]}/32']
         base['peers']=[{
             "public_key":proxy["wg_server_pub"],
             "pre_shared_key":proxy["wg_psk"],
@@ -389,7 +390,6 @@ def add_wireguard(base: dict, proxy: dict):
             "allowed_ips": [
                 "0.0.0.0/0","::/0"
             ]
-            # "address" : f'{proxy["wg_ipv4"]}/32'
         }]
         del base["server_port"]
         del base["server"]

--- a/hiddifypanel/hutils/proxy/xray.py
+++ b/hiddifypanel/hutils/proxy/xray.py
@@ -155,7 +155,7 @@ def to_link(proxy: dict) -> str | dict:
                 "publicKey": proxy["wg_server_pub"],
                 "presharedKey":   proxy["wg_psk"],
                 "reserved": "0,0,0",
-                "ip":"10.0.0.1",
+                "ip":f'{proxy["wg_ipv4"]}/32',
                 "mtu":"1380",
                 "keepalive":"30",
                 "udp":1,


### PR DESCRIPTION
## Problem
When the Hiddify app requests a subscription (based on User-Agent), the panel returns sing-box JSON generated in:
`hiddifypanel/hutils/proxy/singbox.py`.

In this path, the generated WireGuard configuration is missing the top-level `address` field.

As a result:
- The JSON contains no interface address
- The client imports it as `"address": null`
- WireGuard profiles fail to initialize correctly

## Scope
The same issue exists in:
- `singbox.py` (subscription JSON path) — used by Hiddify clients
- `xray.py` (direct/raw link path)

Both were missing the WireGuard local interface address and are patched in this PR.
