### PR TITLE
fix(user): prevent NoneType error when additional_configs_urls is empty

### DIFF
--- a/hiddifypanel/panel/user/user.py
+++ b/hiddifypanel/panel/user/user.py
@@ -71,7 +71,7 @@ class UserView(FlaskView):
         all_configs = hutils.proxy.xrayjson.configs_as_json(c['domains'], c['user'], c['expire_days'], c['profile_title'])
 
         
-        link_res=get_and_merge_urls(hconfig(ConfigEnum.additional_configs_urls).split("\n"))
+        link_res = get_and_merge_urls(hconfig(ConfigEnum.additional_configs_urls).split("\n") if hconfig(ConfigEnum.additional_configs_urls) else [])
         for item in [hconfig(ConfigEnum.additional_configs_xrayjson),*link_res]:
                 if jsitem:=parse_json(item):
                     if isinstance(jsitem,list):
@@ -261,7 +261,7 @@ class UserView(FlaskView):
             resp = ""
         else:
             base_config = hutils.proxy.singbox.configs_as_json(**c)
-            link_res=get_and_merge_urls(hconfig(ConfigEnum.additional_configs_urls).split("\n"))
+            link_res = get_and_merge_urls(hconfig(ConfigEnum.additional_configs_urls).split("\n") if hconfig(ConfigEnum.additional_configs_urls) else [])
             for item in [hconfig(ConfigEnum.additional_configs_singbox),*link_res]:
                 if jsitem:=parse_json(item):
                     if outbounds:=jsitem.get("outbounds"):
@@ -311,7 +311,7 @@ class UserView(FlaskView):
         else:
             # render_template('all_configs.txt', **c, base64=hutils.encode.do_base_64)
             resp = hutils.proxy.xray.make_v2ray_configs(c['domains'], c['user'], c['expire_days'], c['ip_debug'])
-            link_res=get_and_merge_urls(hconfig(ConfigEnum.additional_configs_urls).split("\n"))
+            link_res = get_and_merge_urls(hconfig(ConfigEnum.additional_configs_urls).split("\n") if hconfig(ConfigEnum.additional_configs_urls) else [])
             resp+="\n"+"\n\n".join(link_res)
         
         if base64:


### PR DESCRIPTION
### Description
This PR fixes a `500 Internal Server Error` (specifically `'NoneType' object has no attribute 'split'`) that occurs when the `additional_configs_urls` setting is empty or null in the database.

### Changes
- Improved null-safety in `hiddifypanel/panel/user/user.py`.
- Replaced direct `.split("\n")` call with a conditional check to ensure an empty list is passed to `get_and_merge_urls` if no URLs are configured.

### Why this is needed
When a user hasn't configured any additional URLs, the panel currently crashes while trying to render the user page because it expects a string but receives `None`.
<img width="1183" height="652" alt="image" src="https://github.com/user-attachments/assets/ac1e453a-8195-4ac4-bbdc-ecd54923e585" />
<img width="1080" height="849" alt="image" src="https://github.com/user-attachments/assets/3410ceb2-02cd-47de-be21-f9108edafd44" />
