### PR TITLE
fix: pass base_cmd to background commander thread so commands actually run

### DIFF
--- a/hiddifypanel/panel/run_commander.py
+++ b/hiddifypanel/panel/run_commander.py
@@ -80,7 +80,7 @@ def commander(command: Command, run_in_background=True, **kwargs: str | int) -> 
     else:
         raise Exception('WTF is happening!')
     if run_in_background:
-        t = threading.Thread(target=cmd_in_back, daemon=True)
+        t = threading.Thread(target=cmd_in_back, args=(base_cmd,), daemon=True)
         t.start()
     else:
         return subprocess.check_output(base_cmd, cwd=str(os.environ['HIDDIFY_CONFIG_PATH'])).decode()


### PR DESCRIPTION
## Summary

When `commander()` is called with `run_in_background=True` (the **default**), the background command is **never executed**. The worker thread is created without forwarding the constructed `base_cmd`:

```python
if run_in_background:
    t = threading.Thread(target=cmd_in_back, daemon=True)  # base_cmd is not passed
    t.start()
...
def cmd_in_back(cmd):  # cmd is required
    p = subprocess.Popen(cmd, ...)
    p.wait()
```

So `cmd_in_back()` is invoked with no arguments and raises immediately, before `subprocess.Popen` ever runs:

```
TypeError: cmd_in_back() missing 1 required positional argument: 'cmd'
```

The thread is a daemon and the exception is only logged, so the calling task/request still appears to "succeed" while having **no effect**.

## Impact

Every background `commander()` action silently does nothing, including:

- `Command.apply` — the panel **"Apply configuration"** action; configs are never regenerated and no progress/log is shown in the panel.
- `Command.apply_users` — added / removed / disabled users are never written to the live proxy config.
- `Command.restart_services`, `Command.update`, `Command.install`, `Command.get_cert`, etc.

This has a real security / billing impact for anyone running paid or private nodes:

- **A user whose account is deleted stays connected**, because `apply_users` never removes their UUID from the live sing-box / xray config.
- **A user who is over quota or past their expiry date stays connected**, because the automatic disable + apply never takes effect on the live config.

So revocation from the panel does not actually cut users off until some `run_in_background=False` path (e.g. a manual `bash apply_configs.sh` on the server) happens to regenerate the config.

## Root cause

Regression introduced in 4adef40b ("fix: zombie process"), which moved the background `subprocess.Popen(base_cmd, ...)` into a `cmd_in_back` thread (to `wait()` on and reap the child) but did not forward `base_cmd` to the thread.

## Fix

Pass `base_cmd` to the thread:

```python
t = threading.Thread(target=cmd_in_back, args=(base_cmd,), daemon=True)
```

## Testing

Reproduced and verified on a 12.3.x deployment. Before the fix, the background-tasks worker logged the `TypeError` on every panel apply and deleted / expired users remained connected to the live config. After this one-line change, the background command runs: the panel apply executes (progress/log returns) and user revocations take effect.
