### PR TITLE
fix(subscription): recognize InHive via is_v2ray (base64 links) to preserve kcp

### DIFF
--- a/hiddifypanel/hutils/flask.py
+++ b/hiddifypanel/hutils/flask.py
@@ -79,7 +79,7 @@ def __parse_user_agent(ua: str) -> dict:
     res['os_version'] = uaa.os.version
     res['is_clash'] = re.match('^(Clash|Stash)', ua, re.IGNORECASE) and True
     res['is_clash_meta'] = re.match('^(Clash-verge|Clash-?Meta|Stash|NekoBox|NekoRay|Pharos|hiddify-desktop)', ua, re.IGNORECASE) and True
-    res['is_singbox'] = re.match('^(HiddifyNext|Dart|SFI|SFA)', ua, re.IGNORECASE) and True
+    res['is_singbox'] = re.match('^(HiddifyNext|Dart|SFI|SFA|InHive)', ua, re.IGNORECASE) and True
     res['is_hiddify'] = re.match('^(HiddifyNext)', ua, re.IGNORECASE) and True
     res['is_hiddify_prefere_xray'] = re.match('^(HiddifyNextX)', ua, re.IGNORECASE) and True
     res['is_streisand'] = re.match('^(Streisand)', ua, re.IGNORECASE) and True

--- a/hiddifypanel/hutils/flask.py
+++ b/hiddifypanel/hutils/flask.py
@@ -79,7 +79,7 @@ def __parse_user_agent(ua: str) -> dict:
     res['os_version'] = uaa.os.version
     res['is_clash'] = re.match('^(Clash|Stash)', ua, re.IGNORECASE) and True
     res['is_clash_meta'] = re.match('^(Clash-verge|Clash-?Meta|Stash|NekoBox|NekoRay|Pharos|hiddify-desktop)', ua, re.IGNORECASE) and True
-    res['is_singbox'] = re.match('^(HiddifyNext|Dart|SFI|SFA|InHive)', ua, re.IGNORECASE) and True
+    res['is_singbox'] = re.match('^(HiddifyNext|Dart|SFI|SFA)', ua, re.IGNORECASE) and True
     res['is_hiddify'] = re.match('^(HiddifyNext)', ua, re.IGNORECASE) and True
     res['is_hiddify_prefere_xray'] = re.match('^(HiddifyNextX)', ua, re.IGNORECASE) and True
     res['is_streisand'] = re.match('^(Streisand)', ua, re.IGNORECASE) and True
@@ -103,10 +103,10 @@ def __parse_user_agent(ua: str) -> dict:
             res['singbox_version'] = [1, 13, 0]
 
 
-    res['is_v2ray'] = re.match('^(Hiddify|FoXray|Fair|v2rayNG|SagerNet|Shadowrocket|V2Box|Loon|Liberty)', ua, re.IGNORECASE) and True
+    res['is_v2ray'] = re.match('^(Hiddify|FoXray|Fair|v2rayNG|SagerNet|Shadowrocket|V2Box|Loon|Liberty|InHive)', ua, re.IGNORECASE) and True
 
     if res['os'] == 'Other':
-        if re.match('^(FoXray|Fair|Shadowrocket|V2Box|Loon|Liberty)', ua, re.IGNORECASE):
+        if re.match('^(FoXray|Fair|Shadowrocket|V2Box|Loon|Liberty|InHive)', ua, re.IGNORECASE):
             res['os'] = 'iOS'
             # res['os_version']
 

--- a/hiddifypanel/panel/user/user.py
+++ b/hiddifypanel/panel/user/user.py
@@ -157,7 +157,7 @@ class UserView(FlaskView):
             return None
 
         ua = request.user_agent.string
-        if g.user_agent['is_singbox'] or re.match('^(HiddifyNext|Dart|SFI|SFA|InHive)', ua, re.IGNORECASE):
+        if g.user_agent['is_singbox'] or re.match('^(HiddifyNext|Dart|SFI|SFA)', ua, re.IGNORECASE):
             return self.full_singbox_imp()
 
         if re.match('^(Clash-verge|Clash-?Meta|Stash|NekoBox|NekoRay|Pharos|hiddify-desktop)', ua, re.IGNORECASE):
@@ -172,7 +172,7 @@ class UserView(FlaskView):
             elif g.user_agent.get('is_streisand'):
                 return self.xray()
 
-        if re.match('^(Hiddify|FoXray|Fair|v2rayNG|SagerNet|Shadowrocket|V2Box|Loon|Liberty|Streisand)', ua, re.IGNORECASE):
+        if re.match('^(Hiddify|FoXray|Fair|v2rayNG|SagerNet|Shadowrocket|V2Box|Loon|Liberty|Streisand|InHive)', ua, re.IGNORECASE):
             return self.links_imp(base64=True)
 
     @route('/clash/<meta_or_normal>/proxies.yml')

--- a/hiddifypanel/panel/user/user.py
+++ b/hiddifypanel/panel/user/user.py
@@ -157,7 +157,7 @@ class UserView(FlaskView):
             return None
 
         ua = request.user_agent.string
-        if g.user_agent['is_singbox'] or re.match('^(HiddifyNext|Dart|SFI|SFA)', ua, re.IGNORECASE):
+        if g.user_agent['is_singbox'] or re.match('^(HiddifyNext|Dart|SFI|SFA|InHive)', ua, re.IGNORECASE):
             return self.full_singbox_imp()
 
         if re.match('^(Clash-verge|Clash-?Meta|Stash|NekoBox|NekoRay|Pharos|hiddify-desktop)', ua, re.IGNORECASE):


### PR DESCRIPTION
Supersedes the original approach in this PR. Instead of adding InHive to the sing-box User-Agent group, this routes it to the base64 share-links group (`is_v2ray`).

**Why the change from sing-box to base64 links**

InHive is a universal client (sing-box + Xray parity) that ingests base64 share-links natively. The sing-box branch (`hutils/proxy/singbox.py`) drops kcp — `if proxy['l3'] == "kcp": return {... "msg": "does not support kcp" ...}`. The base64 branch (`links_imp` → `make_v2ray_configs` → `to_link`) emits every configured proxy including kcp, so it's the only branch that delivers the full set. Routing InHive through sing-box would silently strip kcp from its users.

InHive also isn't affected by the xray-json branch (which drops hysteria2/tuic), since that only fires for v2rayNG≥1.8.17 / Streisand — so it lands cleanly on the base64 links branch.

**Changes**
- `hiddifypanel/hutils/flask.py`: remove InHive from `is_singbox`, add to `is_v2ray`.
- `hiddifypanel/panel/user/user.py`: mirror the same in the routing branch.

**On safety:** InHive uses per-install localhost auth (no open unauthenticated local proxy), so serving it the full config set carries no additional exposure. UA format: `InHive/<ver> (<platform>; <hwid>)`. Releases: github.com/TwilgateLabs.