### PR TITLE
Add Cloudflare Speed Test to the user tools panel

### DIFF
--- a/hiddifypanel/panel/user/templates/home/speedtest.html
+++ b/hiddifypanel/panel/user/templates/home/speedtest.html
@@ -8,6 +8,8 @@
         {{_("user.home.speedtest.download")}}</a>
     <a href="/{{hconfigs[ConfigEnum.proxy_path]}}/speedtest/?run" class="btn hbtn bg-h-blue">
         {{_("user.home.speedtest.two_ways")}}</a>
+    <a href="https://speed.cloudflare.com/" target="_blank" rel="noopener noreferrer"
+        class="btn hbtn bg-h-purple">Cloudflare Speed Test</a>
 </div>
 <br/>
 IP: {{ip_debug}}


### PR DESCRIPTION
## What changed

Adds a Cloudflare Speed Test button beside the existing self-hosted upload, download, and two-way tests. The external page opens in a new tab with `noopener noreferrer`.

## Why

The self-hosted test measures the client-to-server path. Cloudflare Speed Test provides a complementary measurement of the active internet/proxy path without bundling or embedding third-party code in Hiddify Panel.

## Validation

Verified the generated link target and safe new-tab attributes. The existing self-hosted speedtest controls are unchanged.