### PR TITLE
feat(telegram): add telEgo backend

### DIFF
--- a/hiddifypanel/drivers/telegram_metrics.py
+++ b/hiddifypanel/drivers/telegram_metrics.py
@@ -1,0 +1,36 @@
+import re
+from decimal import Decimal
+
+_PROMETHEUS_NUMBER = r"([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)"
+_TELEMT_PATTERN = re.compile(
+    r'telemt_user_octets_(from_client|to_client)\{user="([^"]+)"\}\s+'
+    + _PROMETHEUS_NUMBER
+)
+_TELEGO_PATTERN = re.compile(
+    r'telego_traffic_(in|out)_bytes_total\{[^}]*user="([^"]+)"[^}]*\}\s+'
+    + _PROMETHEUS_NUMBER
+)
+
+
+def parse_usage_metrics(raw_output: str, telegram_lib: str) -> dict[str, dict[str, int]]:
+    if telegram_lib == "telemt":
+        pattern = _TELEMT_PATTERN
+        upload_direction = "from_client"
+    elif telegram_lib == "telego":
+        pattern = _TELEGO_PATTERN
+        upload_direction = "in"
+    else:
+        return {}
+
+    data = {}
+    for line in raw_output.splitlines():
+        match = pattern.search(line)
+        if not match:
+            continue
+
+        direction, user, raw_value = match.groups()
+        usage = data.setdefault(user, {"down": 0, "up": 0})
+        key = "up" if direction == upload_direction else "down"
+        usage[key] = int(Decimal(raw_value))
+
+    return data

--- a/hiddifypanel/drivers/telemt_api.py
+++ b/hiddifypanel/drivers/telemt_api.py
@@ -1,10 +1,10 @@
 import json
 import os
-import re
 
 import requests
 
 from .abstract_driver import DriverABS
+from .telegram_metrics import parse_usage_metrics
 from hiddifypanel.models import User, hconfig, ConfigEnum
 from hiddifypanel.panel.run_commander import Command, commander
 import redis
@@ -21,7 +21,7 @@ class TelemtApi(DriverABS):
         return self.redis_client
 
     def is_enabled(self) -> bool:
-        return hconfig(ConfigEnum.telegram_enable) and hconfig(ConfigEnum.telegram_lib)=="telemt"
+        return hconfig(ConfigEnum.telegram_enable) and hconfig(ConfigEnum.telegram_lib) in {"telemt", "telego"}
 
     def __init__(self) -> None:
         super().__init__()
@@ -50,34 +50,7 @@ class TelemtApi(DriverABS):
         return resp.text
 
     def __get_tg_usages(self) -> dict:
-        raw_output = self.get_metric()
-        data = {}
-
-        # Example lines:
-        # telemt_user_octets_from_client{user="uuid"} 1983
-        # telemt_user_octets_to_client{user="uuid"} 2171
-
-        pattern = re.compile(
-            r'telemt_user_octets_(from_client|to_client)\{user="([^"]+)"\}\s+(\d+)'
-        )
-
-        for line in raw_output.splitlines():
-            match = pattern.search(line)
-            if not match:
-                continue
-
-            direction, user, value = match.groups()
-            value = int(value)
-
-            if user not in data:
-                data[user] = {"down": 0, "up": 0}
-
-            if direction == "from_client":
-                data[user]["up"] = value
-            else:  # to_client
-                data[user]["down"] = value
-
-        return data
+        return parse_usage_metrics(self.get_metric(), hconfig(ConfigEnum.telegram_lib))
 
     def __get_local_usage(self) -> dict:
         usage_data = self.get_redis_client() .get(USERS_USAGE)

--- a/hiddifypanel/panel/admin/SettingAdmin.py
+++ b/hiddifypanel/panel/admin/SettingAdmin.py
@@ -255,6 +255,7 @@ def get_config_form():
                     ("python", _("lib.telegram.python")),
                     ("tgo", _("lib.telegram.go")),
                     ("telemt", _("lib.telegram.telemt")),
+                    ("telego", "telEgo (no ad tag)"),
                     # ("orig", _("lib.telegram.orignal")),
                 ]
                 field = wtf.SelectField(_("config.telegram_lib.label"), choices=libs, description=_("config.telegram_lib.description"), default=hconfig(ConfigEnum.telegram_lib))

--- a/hiddifypanel/panel/commercial/restapi/v2/user/mtproxies.py
+++ b/hiddifypanel/panel/commercial/restapi/v2/user/mtproxies.py
@@ -36,7 +36,7 @@ class MTProxiesAPI(MethodView):
 
             # make mtproxy link
             raw_sec = hconfig(ConfigEnum.shared_secret, d.child_id)
-            if hconfig(ConfigEnum.telegram_lib)=="telemt":
+            if hconfig(ConfigEnum.telegram_lib) in {"telemt", "telego"}:
                 raw_sec=g.account.uuid
             secret_hex = str(raw_sec).replace('-', '')
             telegram_faketls_domain_hex = hconfig(ConfigEnum.telegram_fakedomain, d.child_id).encode('utf-8').hex()

--- a/hiddifypanel/panel/user/templates/home/telegram.html
+++ b/hiddifypanel/panel/user/templates/home/telegram.html
@@ -1,6 +1,10 @@
 {% macro tg_proxy_btn(d) -%}
 <div class="btn-group">
-    {% set hexuuid=hconfigs[ConfigEnum.shared_secret].replace("-","") %}
+    {% if hconfigs[ConfigEnum.telegram_lib] in ["telemt", "telego"] %}
+    {% set hexuuid=user.uuid.replace("-", "") %}
+    {% else %}
+    {% set hexuuid=hconfigs[ConfigEnum.shared_secret].replace("-", "") %}
+    {% endif %}
     <a href="tg://proxy?server={{d.domain}}&amp;port=443&amp;secret=ee{{hexuuid}}{{hconfigs[ConfigEnum.telegram_fakedomain].encode('utf-8').hex()}}" class="btn btn-primary orig-link">{{_("user.home.telegram.clickbtn")}}
         <span class="badge ltr badge-info">{{d.alias or d.domain}}</span></a>
 </div>


### PR DESCRIPTION
Add telEgo as a selectable Telegram proxy backend.

This change:

- generates per-user UUID secrets for telEgo links;
- reads telEgo per-user traffic counters from the existing metrics endpoint;
- preserves Telemt accounting through the shared parser;
- handles integer, decimal, and scientific-notation Prometheus counter values.

A companion Hiddify Manager contribution installs telEgo v0.5.4 and generates its configuration: hiddify/Hiddify-Manager#5537.

The initial integration uses telEgo as an MTProxy backend only. Hiddify's current Telegram fake-domain setting is not an owned WEB hostname with a certificate, so exposing telEgo's WEB carriers requires a separate frontend and settings change. telEgo also does not support advertising tags.

Validation completed:

- Python compilation for all changed modules;
- Ruff check for the new metrics parser;
- focused Telemt and telEgo metrics parsing checks, including scientific notation;
- Jinja parsing and per-user link rendering checks.
